### PR TITLE
Ruby 2.5.8 → Ruby 2.6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget -qnv https://chromedriver.storage.googleapis.com/LATEST_RELEASE -O - | 
 mv chromedriver /usr/bin/
 
 #######################################################################################################################
-FROM ruby:2.5.8
+FROM ruby:2.6.10
 
 RUN mkdir -p /var/log/supervisor
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 RUN gem install bundler
-RUN curl -0 -L http://npmjs.org/install.sh | sh
+RUN curl -0 -L https://registry.npmjs.org/npm/-/npm-6.4.1.tgz | tar zxvf - && cd package && ./configure && make && make install
+
+WORKDIR /usr/src/app
+RUN rm -rf ./package


### PR DESCRIPTION
## 概要

- Ruby バージョンアップ対応
- このブランチは記録用なので、マージ対応はしない予定です（そのため Draft にしています）

## 調査記録

https://github.com/sikmi/bondo-api/issues/7144